### PR TITLE
remove deleted channels from discord's README

### DIFF
--- a/discord-readme.md
+++ b/discord-readme.md
@@ -33,31 +33,19 @@ NOTE: EddieBot is still in development, and there might be a few words flagged b
 **Information Regarding Channels:**
 TEXT CHANNELS: These consist of the server's main text channels, that are for discourse regarding topics that aren't very tech-specific, and aren't off-topic
 
+GENERAL DISCUSSION:
+
 -> #general: main text chat
 
 -> #introductions: give yourself an introduction, and familiarising with the community
 
--> #opensource: discussing interesting open source news and information, that may or may not be related to EddieHubCommunity
-
--> #hackathons: the prime area to get notified about upcoming hackathons, and discussing about them
-
--> #mlh: Major League Hacking -> see more at https://mlh.io/
-
 -> #help: ask for help or provide help to the members of the community
 
--> #ideas: got an idea / suggestion for the community? We love hearing new ideas :nerd: 
-
--> #organisation: our community's GitHub org
-
--> #first-timers: discussion about getting :green_square: 
-
--> #good-first-issues: get started with open source and get your :green_square: - opportunities are provided for new contributors - discussions not to happen here as this is just for people to share links, please discuss in #first-timers
+-> #ideas: got an idea / suggestion for the community? We love hearing new ideas :nerd:
 
 -> #content-share: share web content
 
 -> #bot-chat: discuss bots, esp. regarding development of EddieBot
-
--> #battle-stations: here you can start a battle of course with battlesnake
 
 DAILY:
 
@@ -66,6 +54,24 @@ DAILY:
 -> #standup: everyday of code, give us your standup updates! What you did yesterday,what you plan to do today and any blockers?
 
 -> #achievements: share your personal achievements with the community
+
+COMMUNITY DISCUSSION:
+
+-> #organisation: our community's GitHub org
+
+-> #good-first-issues: get started with open source and get your :green_square: - opportunities are provided for new contributors - discussions not to happen here as this is just for people to share links, please discuss in #first-timers
+
+-> #first-timers: discussion about getting :green_square: 
+
+-> #hackathons: the prime area to get notified about upcoming hackathons, and discussing about them
+
+-> #mlh: Major League Hacking -> see more at https://mlh.io/
+
+-> #opensource: discussing interesting open source news and information, that may or may not be related to EddieHubCommunity
+
+-> #battle-stations: here you can start a battle of course with battlesnake
+
+-> #public-speaking: improve your soft skills, public speaking and build communities
 
 TECH: Channels regarding specific areas
 

--- a/discord-readme.md
+++ b/discord-readme.md
@@ -41,6 +41,8 @@ TEXT CHANNELS: These consist of the server's main text channels, that are for di
 
 -> #standup: everyday of code, give us your standup updates! What you did yesterday,what you plan to do today and any blockers?
 
+-> #healthfitness: health and fitness caus you want to get those bizeps
+
 -> #opensource: discussing interesting open source news and information, that may or may not be related to EddieHubCommunity
 
 -> #hackathons: the prime area to get notified about upcoming hackathons, and discussing about them
@@ -65,16 +67,9 @@ TEXT CHANNELS: These consist of the server's main text channels, that are for di
 
 TECH: Channels regarding specific areas
 
-->  #ux-ui, #frontend, #backend, #linux, #devops, #cloud, #git, #ml-ai, #databases, #tech-other
-
-CHILLING: Channels to geek out in, mostly about off-topic stuff
-
--> #chatting: geek out about off-topic content
-
--> #healthfitness: health and fitness caus you want to get those bizeps
+->  #ux-ui, #frontend, #backend, #linux, #devops, #git, #ml-ai, #databases, #tech-other
 
 ALERTS
--> #announcements: Announcement channel
--> #livestream: Channel for live stream updates of Eddie's youtube channel
+-> #youtube: Channel for live stream updates of Eddie's youtube channel
 -> #bot-logs: Logs of EddieBotDev
 -> #github: Updates from the github community

--- a/discord-readme.md
+++ b/discord-readme.md
@@ -37,13 +37,6 @@ TEXT CHANNELS: These consist of the server's main text channels, that are for di
 
 -> #introductions: give yourself an introduction, and familiarising with the community
 
--> #achievements: share your personal achievements with the community
-
--> #standup: everyday of code, give us your standup updates! What you did yesterday,what you plan to do today and any blockers?
-
--> #healthfitness: health and fitness because you want to get those biceps
-
-
 -> #opensource: discussing interesting open source news and information, that may or may not be related to EddieHubCommunity
 
 -> #hackathons: the prime area to get notified about upcoming hackathons, and discussing about them
@@ -66,6 +59,14 @@ TEXT CHANNELS: These consist of the server's main text channels, that are for di
 
 -> #battle-stations: here you can start a battle of course with battlesnake
 
+DAILY:
+
+-> #healthfitness: health and fitness because you want to get those biceps
+
+-> #standup: everyday of code, give us your standup updates! What you did yesterday,what you plan to do today and any blockers?
+
+-> #achievements: share your personal achievements with the community
+
 TECH: Channels regarding specific areas
 
 ->  #ux-ui, #frontend, #backend, #linux, #devops, #git, #ml-ai, #databases, #tech-other
@@ -79,4 +80,9 @@ ALERTS:
 -> #github: Updates from the github community
 
 You can raise an issue or a Pull request here -https://github.com/EddieHubCommunity/support/blob/main/discord-readme.md  if you find any necessary changes to be made in the README, get started with open source and get your :green_square: right away!
+
+**Where to join our GITHUB community?**
+
+-> Create an Issue with the type `invite me to the GitHub Community Org`
+https://github.com/EddieHubCommunity/support/issues/new/choose
 

--- a/discord-readme.md
+++ b/discord-readme.md
@@ -74,3 +74,6 @@ ALERTS
 -> #youtube: Channel for live stream updates of Eddie's youtube channel
 -> #bot-logs: Logs of EddieBotDev
 -> #github: Updates from the github community
+
+You can raise an issue or a Pull request here -https://github.com/EddieHubCommunity/support/blob/main/discord-readme.md  if you find any necessary changes to be made in the README,get started with open source and get your :green_square: right away!
+

--- a/discord-readme.md
+++ b/discord-readme.md
@@ -41,7 +41,8 @@ TEXT CHANNELS: These consist of the server's main text channels, that are for di
 
 -> #standup: everyday of code, give us your standup updates! What you did yesterday,what you plan to do today and any blockers?
 
--> #healthfitness: health and fitness caus you want to get those bizeps
+-> #healthfitness: health and fitness because you want to get those biceps
+
 
 -> #opensource: discussing interesting open source news and information, that may or may not be related to EddieHubCommunity
 

--- a/discord-readme.md
+++ b/discord-readme.md
@@ -70,10 +70,13 @@ TECH: Channels regarding specific areas
 
 ->  #ux-ui, #frontend, #backend, #linux, #devops, #git, #ml-ai, #databases, #tech-other
 
-ALERTS
+ALERTS:
+
 -> #youtube: Channel for live stream updates of Eddie's youtube channel
+
 -> #bot-logs: Logs of EddieBotDev
+
 -> #github: Updates from the github community
 
-You can raise an issue or a Pull request here -https://github.com/EddieHubCommunity/support/blob/main/discord-readme.md  if you find any necessary changes to be made in the README,get started with open source and get your :green_square: right away!
+You can raise an issue or a Pull request here -https://github.com/EddieHubCommunity/support/blob/main/discord-readme.md  if you find any necessary changes to be made in the README, get started with open source and get your :green_square: right away!
 


### PR DESCRIPTION
closes #1079 

#### What does this PR do?

removed Chilling section, cloud and chatting channels, moved heathfitness channel to text channels and renamed livestream to youtube.

#### Description of Task to be completed?
update the discord's readme
