### PR TITLE
Use the right label on OSS Project Review template

### DIFF
--- a/.github/ISSUE_TEMPLATE/opensource-review.md
+++ b/.github/ISSUE_TEMPLATE/opensource-review.md
@@ -2,7 +2,7 @@
 name: Open Source Project Review
 about: Please review my project on a live stream
 title: '[REVIEW]'
-labels: oss project review
+labels: open source review
 assignees: ''
 ---
 


### PR DESCRIPTION
closes #1179 

#### What does this PR do?
The label for the Issue Template for OSS Project Review was wrong (it didn't exist). This PR fixes that 🤓 

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/24972335/114307428-39ef3400-9ae8-11eb-9d61-35827644376d.png)
![image](https://user-images.githubusercontent.com/24972335/114307452-5ee3a700-9ae8-11eb-9e0f-e5968e9b87f3.png)
