### PR TITLE
docs: add link to invitation issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![Discord](https://img.shields.io/discord/699608417039286293?style=flat-square)](https://discord.gg/jZQs6Wu)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
-Raise an [issue to join the EddieHub GitHub community](https://github.com/EddieHubCommunity/support/issues/new?assignees=&labels=invite+me+to+the+organisation&template=invitation.md&title=Please+invite+me+to+the+GitHub+Community+Organization).
+Raise an [issue to join the EddieHub GitHub organization](https://github.com/EddieHubCommunity/support/issues/new?assignees=&labels=invite+me+to+the+organisation&template=invitation.md&title=Please+invite+me+to+the+GitHub+Community+Organization).
 
 ### Some vague idea of how we could turn this into a support channel.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![Discord](https://img.shields.io/discord/699608417039286293?style=flat-square)](https://discord.gg/jZQs6Wu)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
-Raise an issue to join the EddieHub GitHub community.
+Raise an [issue to join the EddieHub GitHub community](https://github.com/EddieHubCommunity/support/issues/new?assignees=&labels=invite+me+to+the+organisation&template=invitation.md&title=Please+invite+me+to+the+GitHub+Community+Organization).
 
 ### Some vague idea of how we could turn this into a support channel.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![Discord](https://img.shields.io/discord/699608417039286293?style=flat-square)](https://discord.gg/jZQs6Wu)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
-Raise an [issue to join the EddieHub GitHub organization](https://github.com/EddieHubCommunity/support/issues/new?assignees=&labels=invite+me+to+the+organisation&template=invitation.md&title=Please+invite+me+to+the+GitHub+Community+Organization).
+Raise an [issue to join the EddieHub GitHub organisation](https://github.com/EddieHubCommunity/support/issues/new?assignees=&labels=invite+me+to+the+organisation&template=invitation.md&title=Please+invite+me+to+the+GitHub+Community+Organization).
 
 ### Some vague idea of how we could turn this into a support channel.
 


### PR DESCRIPTION
think it would be a good thing to add a link to the "Invite me to the Github Organization" issue