### PR TITLE
Updated Discord Invitation link in bud.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -31,6 +31,6 @@ Please add a screenshot if applicable
 
 Add any other context about the problem here.
 
-You can also join the discord community [here](https://discord.com/invite/jZQs6Wu)
+You can also join the discord community [here](http://discord.eddiehub.org)
 
 Feel free to check out other cool repositories of EddieHub Community [here](https://github.com/EddieHubCommunity)


### PR DESCRIPTION
Update discord server invite link in the file .github/ISSUE_TEMPLATE/bug.md from https://discord.com/invite/jZQs6Wu to http://discord.eddiehub.org

closes #1401

#### What does this PR do?
Discord Invite link updated

#### Description of Task to be completed?

#### How can this be manually tested?

#### Any background context you want to provide?

#### What is the relevant issue link?
https://github.com/EddieHubCommunity/support/issues/1401
#### Screenshots (if appropriate)

#### Questions:
