### PR TITLE
feat: Add "Ask for help guide" to Discord ReadMe

### DIFF
--- a/discord-readme.md
+++ b/discord-readme.md
@@ -90,3 +90,23 @@ You can raise an issue or a Pull request here -https://github.com/EddieHubCommun
 
 -> Create an Issue with the type `invite me to the GitHub Community Org`
 https://github.com/EddieHubCommunity/support/issues/new/choose
+
+
+**How to ask for help**
+Tips to help you ask questions which will give you a better chance to get the best answers from everyone.
+
+1. **Read through your code first** Your problem could be as simple as a typo or a missing closing tag. 
+2. **Ask Google** Many code problems can be solved with a quick Google, so give this a try first. If that doesn't help, head back here to ask your question, and follow the tips below.
+3. **Clearly describe the problem.** Explain what is happening and what you want to happen. 
+4. **Share your code.** It’s very unlikely that anyone will be able to solve your problem without seeing your code. Share a GitHub repository, a GitHub gist link or format the code by wrapping it in backticks , like the example below. 
+
+    ```
+      //Your code goes here
+    ```
+
+5. **Send screenshots, if relevant** It often helps people to see the browser output, so send over a screenshot of what you can see, in this case. 
+6. **Explain what you have already tried.**  You don't want people to suggest things you have already done. 
+7. **Send updates so people know whether their answer has helped you.** 
+8. **Help other people out when you can.** If people see you helping others, they will be even more likely to help you when you need it. 
+
+

--- a/discord-readme.md
+++ b/discord-readme.md
@@ -15,12 +15,13 @@ and orientation.
 We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
 The following are the guidelines regarding chat on the discord server:
+
 - Using welcoming and inclusive language
 - Being respectful of differing viewpoints and experiences
 - Gracefully accepting constructive criticism
 - Focusing on what is best for the community
 - Showing empathy towards other community members
-Full details on https://github.com/EddieHubCommunity/support/blob/main/CODE_OF_CONDUCT.md
+  Full details on https://github.com/EddieHubCommunity/support/blob/main/CODE_OF_CONDUCT.md
 
 **Enforcement:**
 
@@ -74,7 +75,7 @@ COMMUNITY DISCUSSION:
 
 TECH: Channels regarding specific areas
 
-->  #ux-ui, #frontend, #backend, #linux, #devops, #git, #ml-ai, #databases, #tech-other
+-> #ux-ui, #frontend, #backend, #linux, #devops, #git, #ml-ai, #databases, #tech-other
 
 ALERTS:
 
@@ -84,29 +85,26 @@ ALERTS:
 
 -> #github: Updates from the github community
 
-You can raise an issue or a Pull request here -https://github.com/EddieHubCommunity/support/blob/main/discord-readme.md  if you find any necessary changes to be made in the README, get started with open source and get your :green_square: right away!
+You can raise an issue or a Pull request here -https://github.com/EddieHubCommunity/support/blob/main/discord-readme.md if you find any necessary changes to be made in the README, get started with open source and get your :green_square: right away!
 
 **Where to join our GITHUB community?**
 
 -> Create an Issue with the type `invite me to the GitHub Community Org`
 https://github.com/EddieHubCommunity/support/issues/new/choose
 
-
 **How to ask for help**
 Tips to help you ask questions which will give you a better chance to get the best answers from everyone.
 
-1. **Read through your code first** Your problem could be as simple as a typo or a missing closing tag. 
-2. **Ask Google** Many code problems can be solved with a quick Google, so give this a try first. If that doesn't help, head back here to ask your question, and follow the tips below.
-3. **Clearly describe the problem.** Explain what is happening and what you want to happen. 
-4. **Share your code.** It’s very unlikely that anyone will be able to solve your problem without seeing your code. Share a GitHub repository, a GitHub gist link or format the code by wrapping it in backticks , like the example below. 
+1. **Read through your code first.** Your problem could be as simple as a typo or a missing closing tag.
+2. **Ask Google.** Many code problems can be solved with a quick Google, so give this a try first. If that doesn't help, head back here to ask your question, and follow the tips below.
+3. **Clearly describe the problem.** Explain what is happening and what you want to happen.
+4. **Share your code.** It’s very unlikely that anyone will be able to solve your problem without seeing your code. Share a GitHub repository, a GitHub gist link or format the code by wrapping it in backticks, like the example below.
 
-    ```
-      //Your code goes here
-    ```
+   ```
+     //Your code goes here
+   ```
 
-5. **Send screenshots, if relevant** It often helps people to see the browser output, so send over a screenshot of what you can see, in this case. 
-6. **Explain what you have already tried.**  You don't want people to suggest things you have already done. 
-7. **Send updates so people know whether their answer has helped you.** 
-8. **Help other people out when you can.** If people see you helping others, they will be even more likely to help you when you need it. 
-
-
+5. **Send screenshots, if relevant.** It often helps people to see the browser output, so send over a screenshot of what you can see, in this case.
+6. **Explain what you have already tried.** You don't want people to suggest things you have already done.
+7. **Send updates so people know whether their answer has helped you.**
+8. **Help other people out when you can.** If people see you helping others, they will be even more likely to help you when you need it.


### PR DESCRIPTION
closes #ISSUE-NO

#### What does this PR do?
This pull request adds a section that has a simple guide on how to ask questions to make it easier on everyone to understand the question, problem or blocker that someone is facing.

#### Description of Task to be completed?
Reviewing the steps and accepting that it is clear.

#### How can this be manually tested?
The change should be reflected in [discord-readme.md](https://github.com/EddieHubCommunity/support/blob/main/discord-readme.md).

#### Any background context you want to provide?
I liked the way this guide was explained in Scrimba community. After I took permission from them, I added it here with some modifications.

#### What is the relevant issue link?
not yet available

#### Screenshots (if appropriate)

#### Questions:
There are some things that we might need to change like the point **4. Share your code**. I think that we need to edit it based on what our bots would accept from the users based on their role, right? Or maybe we should enforce using GitHub repositories, gists and screenshots?