### PR TITLE
fix(tools): ignore livestream review

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,3 +17,4 @@ jobs:
         stale-pr-message: 'Stale pull request message'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
+        exempt-issue-labels: 'live stream review'


### PR DESCRIPTION
#### What does this PR do?
This pull request modifies the stalebot configuration to ignore issues with the `live stream review` label. Due to the fact that we are currently backlogged on these, we should not be closing them automatically.

#### Description of Task to be completed?

#### How can this be manually tested?
This is a CRON task. If manual testing is desired, I can add the `workflow_dispatch` trigger.

#### Any background context you want to provide?
Three issues came up in my notifications this evening where Stalebot was trying to close live stream review issues.

#### What is the relevant issue link?
n/a

#### Screenshots (if appropriate)

#### Questions:
