### PR TITLE
fix: github action runs on forks

### DIFF
--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -28,5 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: EddieHubCommunity/gh-action-community/src/statistics@main
+        if: ${{ github.repository_owner == 'EddieHubCommunity' }}
         with:
           firebase-key: ${{ secrets.FIREBASE_KEY }}


### PR DESCRIPTION
#### What does this PR do?

Now github actions won't run on any other org/user than ours

#### Description of the task to be completed?

Limit the github action to only run on the main repository but not forks

#### How can this be manually tested?

All of this is taken from the github documentation:

- [Workflow Syntax](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions)
- [Context and Expression Syntax](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions)

#### Any background context you want to provide?

This is a issue from a lot time fixed in this PR
