### PR TITLE
fix: EddieHubCommunity/support#2074

### DIFF
--- a/.github/ISSUE_TEMPLATE/invitation.yml
+++ b/.github/ISSUE_TEMPLATE/invitation.yml
@@ -23,7 +23,7 @@ body:
       label: Additional Context
       description: Where did you meet Eddie? What do you like about this community/Why do you want to join?
     validations:
-      required: false
+      required: true
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
<!-- If applicable, reference the issue number that this PR closes -->
closes #2074

#### What does this PR do?

Makes Additional Context in the invitation template necessary

#### Description of the task to be completed?

Change from `false` to `true` at https://github.com/EddieHubCommunity/support/blob/main/.github/ISSUE_TEMPLATE/invitation.yml#L26

#### How can this be manually tested?

Cross-checking with GitHub Issue template syntax

#### Any background context you want to provide?

> I think we should make Additional Context obligatory because this would enable the community to know the actual reason why people are getting into EddieHub and would encourage us to work more on that. It would also enable the community members to know the newly joined folks better.
> 
> --- @Sam-Varghese 

#### Is there any relevant issue to this PR?

resolves #2074 
