### PR TITLE
fix: Add a Markdown message in the `Other` template

### DIFF
--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -20,3 +20,8 @@ body:
       description: Is there anything else we should know about this issue?
     validations:
       required: false
+  - type: markdown
+    attributes:
+      value: |
+        You can also join our Discord community [here](http://discord.eddiehub.org)
+        Feel free to check out other cool repositories of the EddieHub Community [here](https://github.com/EddieHubCommunity)


### PR DESCRIPTION
<!-- If applicable, reference the issue number that this PR closes -->

#### What does this PR do?

- Add a Markdown message in the `Other` template.
  - This is for people to see the Discord invitation easier. This is also in all the other issue templates.

#### Description of the task to be completed?

None.

#### How can this be manually tested?

This can be seen by going to my [fork](https://github.com/Panquesito7/support/blob/add_discord_invitation/.github/ISSUE_TEMPLATE/other.yml) of this repository. 🙂

#### Any background context you want to provide?

Nope.

#### Is there any relevant issue to this PR?

- [ ] #2227
- [x] #2026
- [x] #2002
- [x] #1952

#### Questions

None.
