### PR TITLE
fix: Use HTTPS instead in `youtube/generic.md`

### DIFF
--- a/youtube/generic.md
+++ b/youtube/generic.md
@@ -28,7 +28,7 @@ Join our inclusive open source community EddieHub now for FREE at https://www.ed
 
 ## Community Sponsors
 
-Stephen Mount http://github.com/stemount
+Stephen Mount https://github.com/stemount
 
 Nicholas Carrigan https://github.com/nhcarrigan
 


### PR DESCRIPTION
#### What does this PR do?

- Use HTTPS instead in `youtube/generic.md`.

#### How can this be manually tested?

I don't think this applies here.

#### Any background context you want to provide?

Nope.

#### Is there any relevant issue to this PR?

AFAIK, no.

#### Questions

None.
