### PR TITLE
docs: center chat badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 # Community Support
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![Discord](https://img.shields.io/discord/699608417039286293?style=flat-square)](http://discord.eddiehub.org)
+
+<p align="center">
+ <img src= "https://img.shields.io/discord/699608417039286293?style=flat-square)](http://discord.eddiehub.org" >
+</p> 
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 Raise an [issue to join the EddieHub GitHub organisation](https://github.com/EddieHubCommunity/support/issues/new?assignees=&labels=invite+me+to+the+organisation&template=invitation.yml&title=Please+invite+me+to+the+GitHub+Community+Organization).
 


### PR DESCRIPTION
Centre Aligned the chat bagde under "Community Support" section .

resolve #3610  issue by @kendalldoescoding