### PR TITLE
Fixes "update organization invitation to latest version" bug

### DIFF
--- a/.github/workflows/invitation.yml
+++ b/.github/workflows/invitation.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Invite on label
-        uses: vj-abigo/invite-on-label@v1.2
+        uses: vj-abigo/invite-on-label@v1.4
         with:
           organization: EddieHubCommunity
           label: invite me to the organisation


### PR DESCRIPTION

The GitHub Action `invite-on-label` was using version v1.2, which relied on Node.js 12, now deprecated. This PR updates the action to the latest version v1.4, which supports a newer version of Node.js (Node.js 14).

**Changes Made**

- Updated the GitHub Action reference in `support/.github/workflows/invitation.yml` from `v1.2` to `v1.4`.
- Verified compatibility with Node.js 16 based on the release notes.

**Link to Release Notes**

[Release Notes for v1.4](https://github.com/vj-abigo/invite-on-label/releases/tag/v1.4)



**Related Issue**

Closes #5945 



